### PR TITLE
translations:init now push translations of already translated segments

### DIFF
--- a/src/TargetPOGenerator.php
+++ b/src/TargetPOGenerator.php
@@ -46,7 +46,7 @@ class TargetPOGenerator
                 return $this->sourceEntryKeys->contains($key);
             })));
 
-            $this->diffKeys($this->sourceEntryKeys->all(), $valid->keys()->all())
+            $this->sourceEntryKeys->diff($valid->keys()->all())
                 ->each(function ($key) use (&$valid) {
                     $valid->put($key, "");
                 });

--- a/src/TargetPOGenerator.php
+++ b/src/TargetPOGenerator.php
@@ -59,11 +59,6 @@ class TargetPOGenerator
         })->all();
     }
 
-    private function diffKeys($arr1, $arr2)
-    {
-        return collect(array_diff_key($arr1, $arr2));
-    }
-
     private function poData($entries)
     {
         $translations = new Translations();


### PR DESCRIPTION
There was a bug into the code that would prevent already translated segments to be pushed correctly into the backend of Translation.io.

`$valid->put($key, "");` was executed even for translated segments because of the wrong loop and that line erased the existing translations.