### PR TITLE
Don't create GetText directory if empty PO files are returned from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ t__('Hello %s', $user->name);
 t__('%city1% is bigger than %city2%', [ '%city1%' => 'NYC', '%city2%' => 'BXL' ]);
 ```
 
+You don't need another file with source text or translations, everything will
+be synchronized from Translation.io, and stored on PO/MO files.
+
 ## Usage
 
 #### Sync
@@ -173,7 +176,7 @@ Thanks a lot to these contributors for their hard work!
 
 If you want to create a new client for your favorite language or framework, feel
 free to reach us on [contact@translation.io](mailto:contact@translation.io) and
-we'll assist you with the workflow logic and some API documentations.
+we'll assist you with the workflow logic and send you API docs.
 
 #### Ruby on Rails (Ruby)
 

--- a/src/GettextPOGenerator.php
+++ b/src/GettextPOGenerator.php
@@ -64,18 +64,13 @@ class GettextPOGenerator
         $tmpFile = $tmpDir . DIRECTORY_SEPARATOR . 'app.po';
         $this->filesystem->makeDirectory($tmpDir, 0777, true, true);
 
-        # Create pot file (will be kept in app structure)
-        $potDir = $this->gettextLocalesPath();
-        $potFile = $potDir . DIRECTORY_SEPARATOR . 'app.pot';
-        $this->filesystem->makeDirectory($potDir, 0777, true, true);
-
         # po(t) headers
         $this->setPoHeaders($translations);
 
         # create pot data
-        $translations->toPoFile($potFile);
+        $translations->toPoFile($tmpFile);
         $poLocales = [
-            'pot_data' => $this->filesystem->get($potFile)
+            'pot_data' => $this->filesystem->get($tmpFile)
         ];
 
         # create po data for each language
@@ -139,12 +134,7 @@ class GettextPOGenerator
 
     private function gettextParsePaths()
     {
-        if ($this->application->environment('testing')) {
-            return ['tests/fixtures/gettext'];
-        }
-        else {
-            return $this->config['gettext_parse_paths'];
-        }
+        return $this->config['gettext_parse_paths'];
     }
 
     private function setPoHeaders($translations) {

--- a/src/GettextTranslationSaver.php
+++ b/src/GettextTranslationSaver.php
@@ -34,15 +34,17 @@ class GettextTranslationSaver
         $poFile = $localeDir . DIRECTORY_SEPARATOR . 'app.po';
         $moFile = $lcMessagesDir . DIRECTORY_SEPARATOR . 'app.mo';
 
-        $this->filesystem->makeDirectory($localeDir, 0777, true, true);
-        $this->filesystem->makeDirectory($lcMessagesDir, 0777, true, true);
+        if ($this->hasAnySegments($poContent)) {
+            $this->filesystem->makeDirectory($localeDir, 0777, true, true);
+            $this->filesystem->makeDirectory($lcMessagesDir, 0777, true, true);
 
-        // Save to po file
-        $this->filesystem->put($poFile, $poContent);
+            // Save to po file
+            $this->filesystem->put($poFile, $poContent);
 
-        // Save to mo files
-        $translations = Translations::fromPoFile($poFile);
-        $translations->toMoFile($moFile);
+            // Save to mo files
+            $translations = Translations::fromPoFile($poFile);
+            $translations->toMoFile($moFile);
+        }
     }
 
     private function localePath($locale)
@@ -53,5 +55,10 @@ class GettextTranslationSaver
     private function gettextPath()
     {
         return base_path($this->config['gettext_locales_path']);
+    }
+
+    // poContent has only the headers
+    private function hasAnySegments($poContent) {
+        return substr_count($poContent, 'msgid "') > 1;
     }
 }

--- a/tests/Integration/InitTest.php
+++ b/tests/Integration/InitTest.php
@@ -12,6 +12,7 @@ class InitTest extends TestCase
     {
         app()['config']->set('translationio.target_locales', ['fr-BE', 'lv', 'ru']);
         app()['config']->set('translationio.key', 'b641be726cfc42a3a0e2daa7f6fdda5c');
+        app()['config']->set('translationio.gettext_parse_paths', ['tests/fixtures/gettext']);
 
         $this->addTranslationFixture('fr-BE', [], 'auth', [
             'fields' => [
@@ -93,6 +94,7 @@ EOT;
     {
         app()['config']->set('translationio.target_locales', ['fr-BE']);
         app()['config']->set('translationio.key', '2953c30ba10244f185fd8edc8443efe1');
+        app()['config']->set('translationio.gettext_parse_paths', ['tests/fixtures/gettext']);
 
         $frBePOContent = <<<EOT
 msgid ""
@@ -308,6 +310,19 @@ EOT;
             $this->filesystem->get($poPath),
             $expectedFrBePoContent
         );
+    }
 
+    public function testItWorksWithNoGettext()
+    {
+        app()['config']->set('translationio.target_locales', ['fr-BE', 'lv', 'ru']);
+        app()['config']->set('translationio.key', '1bd053fe4148408cbd869101dcae9419');
+
+        // a directory without Gettext
+        app()['config']->set('translationio.gettext_parse_paths', ['config']);
+
+        $this->cassette('integration/init_with_no_gettext.yml');
+        $this->artisan('translation:init');
+
+        $this->assertDirectoryNotExists($this->gettextDir());
     }
 }

--- a/tests/Integration/SyncTest.php
+++ b/tests/Integration/SyncTest.php
@@ -13,6 +13,7 @@ class SyncTest extends TestCase
         Carbon::setTestNow(Carbon::createFromTimestamp('1520275983'));
         app()['config']->set('translationio.target_locales', ['fr-BE', 'lv', 'ru']);
         app()['config']->set('translationio.key', 'b641be726cfc42a3a0e2daa7f6fdda5c');
+        app()['config']->set('translationio.gettext_parse_paths', ['tests/fixtures/gettext']);
 
         $this->addTranslationFixture('en', [], 'auth', [
             'password' => 'Password changed',
@@ -200,6 +201,7 @@ EOT;
         Carbon::setTestNow(Carbon::createFromTimestamp('1520275983'));
         app()['config']->set('translationio.target_locales', ['fr-BE', 'lv', 'ru']);
         app()['config']->set('translationio.key', 'b641be726cfc42a3a0e2daa7f6fdda5c');
+        app()['config']->set('translationio.gettext_parse_paths', ['tests/fixtures/gettext']);
 
         $this->addTranslationFixture('en', [], 'auth', [
             'password' => 'Password changed',
@@ -265,6 +267,7 @@ EOT;
         Carbon::setTestNow(Carbon::createFromTimestamp('1520275983'));
         app()['config']->set('translationio.target_locales', ['fr-BE', 'lv', 'ru']);
         app()['config']->set('translationio.key', 'b641be726cfc42a3a0e2daa7f6fdda5c');
+        app()['config']->set('translationio.gettext_parse_paths', ['tests/fixtures/gettext']);
 
         $this->addTranslationFixture('en', ['subfolder'], 'auth', [
             'password' => 'Password changed',
@@ -341,6 +344,7 @@ EOT;
         Carbon::setTestNow(Carbon::createFromTimestamp('1520275983'));
         app()['config']->set('translationio.target_locales', ['fr-BE', 'lv', 'ru']);
         app()['config']->set('translationio.key', 'b641be726cfc42a3a0e2daa7f6fdda5c');
+        app()['config']->set('translationio.gettext_parse_paths', ['tests/fixtures/gettext']);
 
         $this->addTranslationFixture('en', ['subfolder'], 'auth', [
             'password' => 'Password changed',

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,10 +58,13 @@ EOT;
         return app()['path.lang'] . DIRECTORY_SEPARATOR . $locale;
     }
 
-    protected function gettextPoDir($locale) {
-        return app()['path.lang'] . DIRECTORY_SEPARATOR . 'gettext' . DIRECTORY_SEPARATOR . $locale;
+    protected function gettextDir() {
+        return app()['path.lang'] . DIRECTORY_SEPARATOR . 'gettext';
     }
 
+    protected function gettextPoDir($locale) {
+        return $this->gettextDir() . DIRECTORY_SEPARATOR . $locale;
+    }
 
     protected function gettextPoPath($locale) {
         return $this->gettextPoDir($locale) . DIRECTORY_SEPARATOR . 'app.po';

--- a/tests/fixtures/integration/init_with_no_gettext.yml
+++ b/tests/fixtures/integration/init_with_no_gettext.yml
@@ -1,0 +1,34 @@
+
+-
+    request:
+        method: POST
+        url: 'https://translation.io/api/projects/1bd053fe4148408cbd869101dcae9419/init'
+        headers:
+            Host: translation.io
+            Expect: null
+            Accept-Encoding: null
+            User-Agent: 'GuzzleHttp/6.2.1 curl/7.54.0 PHP/7.2.2'
+            Content-Type: application/x-www-form-urlencoded
+            Accept: null
+        body: 'client=laravel&version=1.0&source_language=en&yaml_po_data_fr-BE=msgid+%22%22%0Amsgstr+%22%22%0A&yaml_po_data_lv=msgid+%22%22%0Amsgstr+%22%22%0A&yaml_po_data_ru=msgid+%22%22%0Amsgstr+%22%22%0A&pot_data=msgid+%22%22%0Amsgstr+%22%22%0A%22Project-Id-Version%3A+Laravel%5Cn%22%0A%22Report-Msgid-Bugs-To%3A+contact%40translation.io%5Cn%22%0A%22Last-Translator%3A+%5Cn%22%0A%22Language-Team%3A+%5Cn%22%0A%22MIME-Version%3A+1.0%5Cn%22%0A%22Content-Type%3A+text%2Fplain%3B+charset%3DUTF-8%5Cn%22%0A%22Content-Transfer-Encoding%3A+8bit%5Cn%22%0A%22POT-Creation-Date%3A+2018-01-01T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22PO-Revision-Date%3A+2018-01-02T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22Language%3A+%5Cn%22%0A%22Plural-Forms%3A+nplurals%3DINTEGER%3B+plural%3DEXPRESSION%3B%5Cn%22%0A&po_data_fr-BE=msgid+%22%22%0Amsgstr+%22%22%0A%22Project-Id-Version%3A+Laravel%5Cn%22%0A%22Report-Msgid-Bugs-To%3A+contact%40translation.io%5Cn%22%0A%22Last-Translator%3A+%5Cn%22%0A%22Language-Team%3A+%5Cn%22%0A%22MIME-Version%3A+1.0%5Cn%22%0A%22Content-Type%3A+text%2Fplain%3B+charset%3DUTF-8%5Cn%22%0A%22Content-Transfer-Encoding%3A+8bit%5Cn%22%0A%22POT-Creation-Date%3A+2018-01-01T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22PO-Revision-Date%3A+2018-01-02T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22Language%3A+fr-BE%5Cn%22%0A%22Plural-Forms%3A+nplurals%3D2%3B+plural%3Dn+%3E+1%3B%5Cn%22%0A&po_data_lv=msgid+%22%22%0Amsgstr+%22%22%0A%22Project-Id-Version%3A+Laravel%5Cn%22%0A%22Report-Msgid-Bugs-To%3A+contact%40translation.io%5Cn%22%0A%22Last-Translator%3A+%5Cn%22%0A%22Language-Team%3A+%5Cn%22%0A%22MIME-Version%3A+1.0%5Cn%22%0A%22Content-Type%3A+text%2Fplain%3B+charset%3DUTF-8%5Cn%22%0A%22Content-Transfer-Encoding%3A+8bit%5Cn%22%0A%22POT-Creation-Date%3A+2018-01-01T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22PO-Revision-Date%3A+2018-01-02T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22Language%3A+lv%5Cn%22%0A%22Plural-Forms%3A+nplurals%3D3%3B+plural%3D%28n+%25+10+%3D%3D+0+%7C%7C+n+%25+100+%3E%3D+11+%26%26+n+%25+100+%3C%3D+19%29+%3F+0+%3A+%28%28n+%25+10+%3D%3D+1+%26%26+n+%25+100+%21%3D+11%29+%3F+1+%3A+2%29%3B%5Cn%22%0A&po_data_ru=msgid+%22%22%0Amsgstr+%22%22%0A%22Project-Id-Version%3A+Laravel%5Cn%22%0A%22Report-Msgid-Bugs-To%3A+contact%40translation.io%5Cn%22%0A%22Last-Translator%3A+%5Cn%22%0A%22Language-Team%3A+%5Cn%22%0A%22MIME-Version%3A+1.0%5Cn%22%0A%22Content-Type%3A+text%2Fplain%3B+charset%3DUTF-8%5Cn%22%0A%22Content-Transfer-Encoding%3A+8bit%5Cn%22%0A%22POT-Creation-Date%3A+2018-01-01T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22PO-Revision-Date%3A+2018-01-02T12%3A00%3A00%2B00%3A00%5Cn%22%0A%22Language%3A+ru%5Cn%22%0A%22Plural-Forms%3A+nplurals%3D3%3B+plural%3D%28n+%25+10+%3D%3D+1+%26%26+n+%25+100+%21%3D+11%29+%3F+0+%3A+%28%28n+%25+10+%3E%3D+2+%26%26+n+%25+10+%3C%3D+4+%26%26+%28n+%25+100+%3C+12+%7C%7C+n+%25+100+%3E+14%29%29+%3F+1+%3A+2%29%3B%5Cn%22%0A&target_languages[]=fr-BE&target_languages[]=lv&target_languages[]=ru'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Content-Type: 'application/json; charset=utf-8'
+            Transfer-Encoding: chunked
+            Connection: keep-alive
+            Status: '200 OK'
+            Cache-Control: 'max-age=0, private, must-revalidate'
+            X-XSS-Protection: '1; mode=block'
+            X-Request-Id: 7ce3f03a-2435-4b22-ac98-1b297b878114
+            ETag: 'W/"4b16736ca5eed7b82660de43df5a769c"'
+            X-Frame-Options: SAMEORIGIN
+            X-Runtime: '0.247534'
+            X-Content-Type-Options: nosniff
+            Date: 'Thu, 08 Mar 2018 09:41:53 GMT'
+            X-Powered-By: 'Phusion Passenger 5.0.24'
+            Server: 'nginx/1.8.1 + Phusion Passenger 5.0.24'
+        body: '{"project_name":"laravel","project_url":"https://translation.io/michael-hoste/laravel","po_data_fr-BE":"msgid \"\"\nmsgstr \"\"\n\"Project-Id-Version: Laravel\\n\"\n\"Report-Msgid-Bugs-To: contact@translation.io\\n\"\n\"Last-Translator: \\n\"\n\"Language-Team: French\\n\"\n\"MIME-Version: 1.0\\n\"\n\"Content-Type: text/plain; charset=UTF-8\\n\"\n\"Content-Transfer-Encoding: 8bit\\n\"\n\"POT-Creation-Date: 2018-01-01T12:00:00+00:00\\n\"\n\"PO-Revision-Date: 2018-03-08 10:41+0100\\n\"\n\"Language: fr_BE\\n\"\n\"Plural-Forms: nplurals=2; plural=n\u003e1;\\n\"\n\"\\n\"\n","po_data_lv":"msgid \"\"\nmsgstr \"\"\n\"Project-Id-Version: Laravel\\n\"\n\"Report-Msgid-Bugs-To: contact@translation.io\\n\"\n\"Last-Translator: \\n\"\n\"Language-Team: Latvian\\n\"\n\"MIME-Version: 1.0\\n\"\n\"Content-Type: text/plain; charset=UTF-8\\n\"\n\"Content-Transfer-Encoding: 8bit\\n\"\n\"POT-Creation-Date: 2018-01-01T12:00:00+00:00\\n\"\n\"PO-Revision-Date: 2018-03-08 10:41+0100\\n\"\n\"Language: lv\\n\"\n\"Plural-Forms: nplurals=3; plural=n%10==1 \u0026\u0026 n%100!=11 ? 0 : n != 0 ? 1 : 2;\\n\"\n\"\\n\"\n","po_data_ru":"msgid \"\"\nmsgstr \"\"\n\"Project-Id-Version: Laravel\\n\"\n\"Report-Msgid-Bugs-To: contact@translation.io\\n\"\n\"Last-Translator: \\n\"\n\"Language-Team: Russian\\n\"\n\"MIME-Version: 1.0\\n\"\n\"Content-Type: text/plain; charset=UTF-8\\n\"\n\"Content-Transfer-Encoding: 8bit\\n\"\n\"POT-Creation-Date: 2018-01-01T12:00:00+00:00\\n\"\n\"PO-Revision-Date: 2018-03-08 10:41+0100\\n\"\n\"Language: ru\\n\"\n\"Plural-Forms: nplurals=3; plural=n%10==1 \u0026\u0026 n%100!=11 ? 0 : n%10\u003e=2 \u0026\u0026 n%10\u003c=4\"\n\" \u0026\u0026 (n%100\u003c10 || n%100\u003e=20) ? 1 : 2;\\n\"\n\"\\n\"\n","yaml_po_data_fr-BE":"msgid \"\"\nmsgstr \"\"\n","yaml_po_data_lv":"msgid \"\"\nmsgstr \"\"\n","yaml_po_data_ru":"msgid \"\"\nmsgstr \"\"\n"}'


### PR DESCRIPTION
It's a way to automatically "disable" GetText. There will be no GetText file to commit then.

