### PR TITLE
Default locale independent to translation setup

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,7 +51,7 @@ class ServiceProvider extends LaravelServiceProvider
 
         $translationIO = new TranslationIO($config);
 
-        $translationIO->setLocale($config['source_locale']);
+        $translationIO->setLocale(config('app.locale'));
     }
 
     private function config()


### PR DESCRIPTION
This PR makes application locale set in config('app.locale') independent to translation setup.
This way one can set any default language he/she wants when working locally or in a server while syncing with translation.io the way defined in config('translation').

Examples:
- Working locally with Greek locale (set in config('app.locale')) enabled, using gettext/json strings in english, while syncing with source language English and target languages Greek and Polish
- Auto-deploying in 2 different application servers with default languages Polish and Greek respectively without any change in translation setup


This shouldn't break previous behavior as long as the config('app.locale')) == config('translation.source_locale'), while giving the flexibility mentioned above.

Having English as source_locale even someone is not using them at all (best practice for easy translations in any language) is also possible through this PR