### PR TITLE
Better generated PHP files code style

### DIFF
--- a/src/PrettyVarExport.php
+++ b/src/PrettyVarExport.php
@@ -20,7 +20,7 @@ class PrettyVarExport
                         . ($indexed ? '' : str_pad($key, $maxLength) . ' => ')
                         . $this->call($value, array_merge($opts, ['indent' => $opts['indent'] . $opts['tab']]));
                 }
-                return "[\n" . implode(",\n", $r) . "\n" . $opts['indent'] . "]";
+                return "[\n" . implode(",\n", $r) . ",\n" . $opts['indent'] . "]";
             case 'boolean':
                 return $var ? 'true' : 'false';
             case 'NULL':

--- a/src/SourceSaver.php
+++ b/src/SourceSaver.php
@@ -58,9 +58,11 @@ class SourceSaver
 
             $translations = $this->applySourceEditInTranslations($translations, $sourceEdit);
 
+            // Leave the extra newline at the end
             $fileContent = <<<'EOT'
 <?php
 return {{translations}};
+
 EOT;
 
             $prettyTranslationsExport = $this->prettyVarExport->call($translations, ['array-align' => true]);

--- a/src/TranslationSaver.php
+++ b/src/TranslationSaver.php
@@ -69,9 +69,11 @@ class TranslationSaver
 
         $this->filesystem->makeDirectory($dir, 0777, true, true);
 
+        // Leave the extra newline at the end
         $fileContent = <<<'EOT'
 <?php
 return {{translations}};
+
 EOT;
 
         $prettyTranslationsExport = $this->prettyVarExport->call($translations, ['array-align' => true]);


### PR DESCRIPTION
Generated PHP files with source and translations now respect better code standards:

 * New line at end of file.
 * Coma after the last item of array.