### PR TITLE
Use the main php-vcr repository again for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,7 @@
       "email": "michael.hoste@gmail.com"
     }
   ],
-  "repositories":[
-    {
-      "type":"vcs",
-      "url":"https://github.com/MichaelHoste/php-vcr.git"
-    }
-  ],
+  "repositories": [],
   "require": {
     "php": ">=7.0",
     "gettext/gettext": "^4.8.4",


### PR DESCRIPTION
After support for Symfony 6 and newest Laravel versions: https://github.com/php-vcr/php-vcr/pull/361