### PR TITLE
Update README.md for Laravel 11 compatibility + update versions in Github Actions tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       COMPOSER_MEMORY_LIMIT: -1
       CC_TEST_REPORTER_ID: 2f4620ac239cc7fdb27b299c24422281b04fd8012820ba173e92c70953385958
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -47,7 +47,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}
       - name: Cache PHP dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.composer_flag }}-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
           - 8.0
           - 8.1
           - 8.2
+          - 8.3
         composer_flag:
           - --prefer-lowest
           -
@@ -31,6 +32,8 @@ jobs:
           - php: 8.1                       # /
             composer_flag: --prefer-lowest # /
           - php: 8.2                       # /
+            composer_flag: --prefer-lowest # /
+          - php: 8.3                       # /
             composer_flag: --prefer-lowest # /
     env:
       COMPOSER_MEMORY_LIMIT: -1

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ php artisan translation:init
 Note: since **Laravel 9**, the `lang` directory and the default set of language files
 used by Laravel are **not** included by default in new projects
 (see [official documentation](https://laravel.com/docs/master/localization#publishing-the-language-files)),
-so may need to run the `lang:publish` command to generate them:
+so you may need to run the `lang:publish` command to generate them:
 
 ~~~bash
 php artisan lang:publish

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Translation.io](https://translation.io/laravel) client for Laravel 5.5+ to 10.x
+# [Translation.io](https://translation.io/laravel) client for Laravel 5.5+ to 11.x
 
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Build Status](https://github.com/translation/laravel/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/translation/laravel/actions/workflows/test.yml)
@@ -17,8 +17,6 @@ Write only the source text, and keep it synchronized with your translators on [T
 <a href="https://translation.io/laravel">
   <img width="720px" alt="Translation.io interface" src="https://translation.io/gifs/translation.gif">
 </a>
-
-[Technical Demo](https://translation.io/videos/laravel.mp4) (2.5min)
 
 Need help? [contact@translation.io](mailto:contact@translation.io)
 
@@ -198,6 +196,16 @@ return [
 ~~~bash
 php artisan translation:init
 ~~~
+
+Note: since **Laravel 9**, the `lang` directory and the default set of language files
+used by Laravel are **not** included by default in new projects
+(see [official documentation](https://laravel.com/docs/master/localization#publishing-the-language-files)),
+so may need to run the `lang:publish` command to generate them:
+
+~~~bash
+php artisan lang:publish
+~~~
+
 
 If you need to add or remove languages in the future, please read
 [this section](#add-or-remove-language) about that.


### PR DESCRIPTION
Laravel 11 was released on March 12, 2024.

Our Laravel package (tio/laravel) appears to be compatible with Laravel 11, so I have update the title of the README file.

I took this opportunity to add a note in the README file about the `lang` directory. Indeed, since the release of Laravel 9, this directory and the default Laravel language files are not included by default on new projects. For projects created with Laravel 9 or a higher version, it is now necessary to run the `lang:publish` command to generate that directory and its language files.

In addition, I updated the Github Actions test suite (`workflows/test.yml`) to include **v8.3** of PHP, and I upgraded the `actions/checkout` and `actions/cache` packages to **v4** (instead of v3). The test suite still passes.

Finally, I removed the link to the demo video from the README file, because the video does not exist on Translation.io anymore (it was outdated anyway).

These changes do not necessarily require a new release of the package on Composer.