### PR TITLE
Add extra newline after `<?php`

### DIFF
--- a/src/SourceSaver.php
+++ b/src/SourceSaver.php
@@ -60,6 +60,7 @@ class SourceSaver
             // Leave the extra newline at the end
             $fileContent = <<<'EOT'
 <?php
+
 return {{translations}};
 
 EOT;

--- a/src/TranslationSaver.php
+++ b/src/TranslationSaver.php
@@ -71,6 +71,7 @@ class TranslationSaver
         // Leave the extra newline at the end
         $fileContent = <<<'EOT'
 <?php
+
 return {{translations}};
 
 EOT;


### PR DESCRIPTION
Following the [Pint codestyles](https://github.com/laravel/pint), there should be an additional new line after the `<?php` opening. 

This seems to be this rule: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/php_tag/blank_line_after_opening_tag.rst