### PR TITLE
PHP 8.5 / Laravel 13 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     env:
       COMPOSER_MEMORY_LIMIT: -1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,7 +52,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}
       - name: Cache PHP dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ matrix.composer_flag }}-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
+          - 8.5
         composer_flag:
           - --prefer-lowest
           -
@@ -38,9 +39,10 @@ jobs:
             composer_flag: --prefer-lowest # /
           - php: 8.4                       # /
             composer_flag: --prefer-lowest # /
+          - php: 8.5                       # /
+            composer_flag: --prefer-lowest # /
     env:
       COMPOSER_MEMORY_LIMIT: -1
-      CC_TEST_REPORTER_ID: 2f4620ac239cc7fdb27b299c24422281b04fd8012820ba173e92c70953385958
     steps:
       - uses: actions/checkout@v4
       - name: Install PHP
@@ -59,10 +61,3 @@ jobs:
         run: composer update --no-interaction --prefer-stable ${{ matrix.composer_flag }}
       - name: Run Specs
         run: vendor/bin/phpunit
-      - name: Publish code coverage
-        if: ${{ matrix.php == '8.1' && matrix.composer_flag == '' }} # only one is needed!
-        uses: paambaati/codeclimate-action@v3.2.0
-        with:
-          coverageLocations: './build/logs/clover.xml:clover'
-          debug: true
-          verifyDownload: true

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Build Status](https://github.com/translation/laravel/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/translation/laravel/actions/workflows/test.yml)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/552e1ddc3f3f604d4908/test_coverage)](https://codeclimate.com/github/translation/laravel/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/552e1ddc3f3f604d4908/maintainability)](https://codeclimate.com/github/translation/laravel/maintainability)
+[![Test Coverage](misc/coverage-badge.svg)](misc/coverage-badge.svg)
 [![Package Version](https://img.shields.io/packagist/v/tio/laravel?style=flat-square)](https://packagist.org/packages/tio/laravel)
 [![Downloads](https://img.shields.io/packagist/dt/tio/laravel.svg?style=flat-square)](https://packagist.org/packages/tio/laravel)
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ To run the specs with latest dependencies:
 ~~~bash
 composer update --no-interaction --prefer-stable
 ./vendor/bin/phpunit
+
 php bin/coverage-badge # Generate coverage badge (misc/coverage-badge.svg)
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Translation.io](https://translation.io/laravel) client for Laravel 5.5+ to 12.x
+# [Translation.io](https://translation.io/laravel) client for Laravel 5.5+ to 13.x
 
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Build Status](https://github.com/translation/laravel/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/translation/laravel/actions/workflows/test.yml)
@@ -401,6 +401,7 @@ To run the specs with latest dependencies:
 ~~~bash
 composer update --no-interaction --prefer-stable
 ./vendor/bin/phpunit
+php bin/coverage-badge # Generate coverage badge (misc/coverage-badge.svg)
 ~~~
 
 ## Contributing

--- a/bin/coverage-badge
+++ b/bin/coverage-badge
@@ -1,0 +1,78 @@
+#!/usr/bin/env php
+<?php
+
+// Parse clover.xml and generate an SVG coverage badge
+
+$cloverFile = __DIR__ . '/../build/logs/clover.xml';
+$badgeFile  = __DIR__ . '/../misc/coverage-badge.svg';
+
+if (!file_exists($cloverFile)) {
+    fwrite(STDERR, "Error: $cloverFile not found. Run phpunit first.\n");
+    exit(1);
+}
+
+$xml = simplexml_load_file($cloverFile);
+
+// Use project-level metrics from clover
+$metrics = $xml->xpath('//project/metrics')[0] ?? null;
+
+if (!$metrics || !isset($metrics['elements']) || !isset($metrics['coveredelements'])) {
+    fwrite(STDERR, "Error: No coverage metrics found in $cloverFile.\n");
+    exit(1);
+}
+
+$totalElements   = (int) $metrics['elements'];
+$coveredElements = (int) $metrics['coveredelements'];
+
+$percentage = $totalElements > 0 ? round(($coveredElements / $totalElements) * 100, 1) : 0;
+
+// Pick color based on coverage
+if ($percentage >= 90) {
+    $color = '#4c1';     // bright green
+} elseif ($percentage >= 75) {
+    $color = '#a3c51c';  // yellow-green
+} elseif ($percentage >= 60) {
+    $color = '#dfb317';  // yellow
+} elseif ($percentage >= 40) {
+    $color = '#fe7d37';  // orange
+} else {
+    $color = '#e05d44';  // red
+}
+
+$label = 'coverage';
+$value = $percentage . '%';
+
+// Compute text widths (approximate)
+$labelWidth  = strlen($label) * 6.5 + 10;
+$valueWidth  = strlen($value) * 6.5 + 10;
+$totalWidth  = $labelWidth + $valueWidth;
+$labelCenter = $labelWidth / 2;
+$valueCenter = $labelWidth + $valueWidth / 2;
+
+$svg = <<<SVG
+<svg xmlns="http://www.w3.org/2000/svg" width="{$totalWidth}" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="a">
+    <rect width="{$totalWidth}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#a)">
+    <rect width="{$labelWidth}" height="20" fill="#555"/>
+    <rect x="{$labelWidth}" width="{$valueWidth}" height="20" fill="{$color}"/>
+    <rect width="{$totalWidth}" height="20" fill="url(#b)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="{$labelCenter}" y="15" fill="#010101" fill-opacity=".3">{$label}</text>
+    <text x="{$labelCenter}" y="14">{$label}</text>
+    <text x="{$valueCenter}" y="15" fill="#010101" fill-opacity=".3">{$value}</text>
+    <text x="{$valueCenter}" y="14">{$value}</text>
+  </g>
+</svg>
+SVG;
+
+@mkdir(dirname($badgeFile), 0777, true);
+file_put_contents($badgeFile, $svg);
+
+echo "Coverage: {$percentage}% — Badge written to {$badgeFile}\n";

--- a/bin/coverage-badge
+++ b/bin/coverage-badge
@@ -16,15 +16,17 @@ $xml = simplexml_load_file($cloverFile);
 // Use project-level metrics from clover
 $metrics = $xml->xpath('//project/metrics')[0] ?? null;
 
-if (!$metrics || !isset($metrics['elements']) || !isset($metrics['coveredelements'])) {
+if (!$metrics || !isset($metrics['statements'])) {
     fwrite(STDERR, "Error: No coverage metrics found in $cloverFile.\n");
     exit(1);
 }
 
-$totalElements   = (int) $metrics['elements'];
-$coveredElements = (int) $metrics['coveredelements'];
+// TPC = (coveredconditionals + coveredstatements + coveredmethods) / (conditionals + statements + methods)
+// cf. https://openclover.org/doc/manual/latest/faq--how-are-coverage-percentages-calculated.html
+$total   = (int) $metrics['conditionals'] + (int) $metrics['statements'] + (int) $metrics['methods'];
+$covered = (int) $metrics['coveredconditionals'] + (int) $metrics['coveredstatements'] + (int) $metrics['coveredmethods'];
 
-$percentage = $totalElements > 0 ? round(($coveredElements / $totalElements) * 100, 1) : 0;
+$percentage = $total > 0 ? round(($covered / $total) * 100, 1) : 0;
 
 // Pick color based on coverage
 if ($percentage >= 90) {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "guzzlehttp/guzzle": ">=6.3"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=5.7.27 <11",
+    "phpunit/phpunit": ">=5.7.27",
     "php-vcr/php-vcr": "^1.3",
     "squizlabs/php_codesniffer": "~3.0",
     "orchestra/testbench": ">=3.1"

--- a/misc/coverage-badge.svg
+++ b/misc/coverage-badge.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="104.5" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="a">
+    <rect width="104.5" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#a)">
+    <rect width="62" height="20" fill="#555"/>
+    <rect x="62" width="42.5" height="20" fill="#dfb317"/>
+    <rect width="104.5" height="20" fill="url(#b)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="31" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+    <text x="31" y="14">coverage</text>
+    <text x="83.25" y="15" fill="#010101" fill-opacity=".3">72.4%</text>
+    <text x="83.25" y="14">72.4%</text>
+  </g>
+</svg>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
          bootstrap="tests/autoload.php"
          colors="true"
          processIsolation="false"
@@ -8,9 +8,6 @@
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
     </report>
@@ -21,4 +18,9 @@
     </testsuite>
   </testsuites>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/GettextTranslator.php
+++ b/src/GettextTranslator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tio\Laravel;
+
+use Gettext\Translator;
+
+class GettextTranslator extends Translator
+{
+    public function __construct()
+    {
+        $this->defaultDomain('');
+    }
+
+    protected function getTranslation($domain, $context, $original)
+    {
+        $domain  = $domain ?? '';
+        $context = $context ?? '';
+
+        return parent::getTranslation($domain, $context, $original);
+    }
+
+    protected function getPluralIndex($domain, $n, $fallback)
+    {
+        $domain = $domain ?? '';
+
+        return parent::getPluralIndex($domain, $n, $fallback);
+    }
+}

--- a/src/TranslationIO.php
+++ b/src/TranslationIO.php
@@ -3,7 +3,6 @@
 namespace Tio\Laravel;
 
 use Illuminate\Support\Facades\App;
-use Gettext\Translator;
 use Gettext\Translations;
 use Illuminate\Filesystem\Filesystem;
 
@@ -40,7 +39,7 @@ class TranslationIO
 
     private function loadGettextForLocale($locale)
     {
-        $translator = new Translator();
+        $translator = new GettextTranslator();
         $moPath = $this->moPath($locale);
 
         if (file_exists($moPath)) {


### PR DESCRIPTION
  Add PHP 8.5 support

  - Fix null offset deprecation in GettextTranslator (cf. #40, thanks @armandsar)
  - Relax PHPUnit constraint and upgrade to PHPUnit 13
  - Add PHP 8.5 to GitHub Actions matrix
  - Update actions/checkout and actions/cache to v5 (Node.js 20 deprecation)
  - Replace Code Climate coverage with a local SVG badge generator (bin/coverage-badge)