### PR TITLE
fix: preserve ignored_key_prefixes files across TranslationSaver rebuild (#39)

### DIFF
--- a/src/TranslationSaver.php
+++ b/src/TranslationSaver.php
@@ -9,6 +9,7 @@ use Illuminate\Translation\Translator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use SplFileInfo;
+use Symfony\Component\Finder\Finder;
 
 class TranslationSaver
 {
@@ -25,6 +26,8 @@ class TranslationSaver
      */
     private $prettyVarExport;
 
+    private $config;
+
     public function __construct(
         Application $application,
         FileSystem $fileSystem,
@@ -33,10 +36,16 @@ class TranslationSaver
         $this->application = $application;
         $this->filesystem = $fileSystem;
         $this->prettyVarExport = $prettyVarExport;
+        $this->config = $application['config']['translation'];
     }
 
     public function call($locale, $translationsDotted)
     {
+        // Snapshot keys that belong to ignored prefixes before wiping the directory,
+        // so they can be restored after the rebuild (they are never sent to translation.io
+        // and therefore never appear in the API response).
+        $ignoredKeysDotted = $this->snapshotIgnoredKeys($locale);
+
         // the content of the localePath will be recreated from scratch
         $this->filesystem->deleteDirectory($this->localePath($locale));
 
@@ -48,9 +57,103 @@ class TranslationSaver
             }
         }
 
+        // Merge the ignored keys back in so that they survive the rebuild.
+        foreach ($ignoredKeysDotted as $key => $value) {
+            if ($value !== '' && ! is_null($value)) {
+                Arr::set($translationsWithGroups, $key, $value);
+            }
+        }
+
         foreach ($translationsWithGroups as $group => $translations) {
             $this->save($locale, $group, $translations);
         }
+    }
+
+    /**
+     * Read all translation files in the locale directory and collect only the
+     * key/value pairs whose dotted key matches an ignored_key_prefix.  These
+     * keys are never pushed to translation.io, so we must preserve them
+     * ourselves across the delete-and-rebuild cycle.
+     *
+     * @param  string $locale
+     * @return array  Flat dotted array of ignored key => value pairs.
+     */
+    private function snapshotIgnoredKeys($locale)
+    {
+        $ignoredPrefixes = $this->ignoredKeyPrefixes();
+
+        if (empty($ignoredPrefixes)) {
+            return [];
+        }
+
+        $path = $this->localePath($locale);
+
+        if (! $this->filesystem->exists($path)) {
+            return [];
+        }
+
+        $files = iterator_to_array(
+            Finder::create()->files()->ignoreDotFiles(true)->in($path),
+            false
+        );
+
+        $ignoredKeysDotted = [];
+
+        foreach ($files as $file) {
+            $group        = $file->getBasename('.' . $file->getExtension());
+            $relativePath = $file->getRelativePath();
+
+            // Build the dotted key prefix used inside this file:
+            // subfolder/admin.php → group key prefix "subfolder/admin"
+            $groupKeyPrefix = $relativePath !== ''
+                ? $relativePath . '/' . $group
+                : $group;
+
+            // Normalise directory separators so Windows paths still match.
+            $groupKeyPrefix = str_replace(DIRECTORY_SEPARATOR, '/', $groupKeyPrefix);
+
+            $fileTranslations = Arr::dot(
+                [$group => (array) require $file->getRealPath()]
+            );
+
+            foreach ($fileTranslations as $key => $value) {
+                // Reconstruct the full dotted key as it would appear in
+                // the extractor (subfolder prefix + dotted key).
+                $fullKey = $relativePath !== ''
+                    ? str_replace(DIRECTORY_SEPARATOR, '/', $relativePath) . '/' . $key
+                    : $key;
+
+                if ($this->isIgnoredKey($fullKey, $ignoredPrefixes)) {
+                    $ignoredKeysDotted[$fullKey] = $value;
+                }
+            }
+        }
+
+        return $ignoredKeysDotted;
+    }
+
+    /**
+     * Returns true when $key matches any of the given ignored prefixes,
+     * using the same word-boundary regex as TranslationExtractor.
+     */
+    private function isIgnoredKey($key, array $ignoredPrefixes)
+    {
+        foreach ($ignoredPrefixes as $prefix) {
+            if (preg_match('/^' . preg_quote($prefix, '/') . '\b/', $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function ignoredKeyPrefixes()
+    {
+        if (array_key_exists('ignored_key_prefixes', $this->config)) {
+            return $this->config['ignored_key_prefixes'];
+        }
+
+        return [];
     }
 
 

--- a/tests/TranslationSaverTest.php
+++ b/tests/TranslationSaverTest.php
@@ -41,6 +41,107 @@ class TranslationSaverTest extends TestCase
         $this->assertEquals(['a' => 'A'], $file2);
     }
 
+    public function testItPreservesIgnoredKeyPrefixFiles()
+    {
+        $locale = 'fr';
+
+        // Pre-populate the locale directory with an ignored file.
+        $this->addTranslationFixture($locale, [], 'admin', [
+            'title' => 'Admin panel',
+            'users' => 'Users',
+        ]);
+
+        // Also add a non-ignored file so we can confirm it is still rebuilt.
+        $this->addTranslationFixture($locale, [], 'messages', [
+            'hello' => 'Old hello',
+        ]);
+
+        // Configure "admin" as an ignored prefix — its file should survive the rebuild.
+        app()['config']->set('translation.ignored_key_prefixes', ['admin']);
+
+        // The API response only contains non-ignored keys.
+        $translationsDotted = [
+            'messages.hello' => 'Bonjour',
+        ];
+
+        $this->saver()->call($locale, $translationsDotted);
+
+        // The ignored file must still exist with its original content.
+        $adminFile = $this->filesystem->getRequire($this->localePath($locale) . DIRECTORY_SEPARATOR . 'admin.php');
+        $this->assertEquals(['title' => 'Admin panel', 'users' => 'Users'], $adminFile);
+
+        // The non-ignored file must have been updated from the API response.
+        $messagesFile = $this->filesystem->getRequire($this->localePath($locale) . DIRECTORY_SEPARATOR . 'messages.php');
+        $this->assertEquals(['hello' => 'Bonjour'], $messagesFile);
+    }
+
+    public function testItPreservesIgnoredKeyPrefixesWithSubfolders()
+    {
+        $locale = 'fr';
+
+        // Pre-populate a subfolder file that is fully ignored.
+        $this->addTranslationFixture($locale, ['admin'], 'settings', [
+            'foo' => 'Foo value',
+            'bar' => 'Bar value',
+        ]);
+
+        // A normal (non-ignored) subfolder file.
+        $this->addTranslationFixture($locale, ['public'], 'home', [
+            'welcome' => 'Old welcome',
+        ]);
+
+        app()['config']->set('translation.ignored_key_prefixes', ['admin/settings']);
+
+        $translationsDotted = [
+            'public/home.welcome' => 'Bienvenue',
+        ];
+
+        $this->saver()->call($locale, $translationsDotted);
+
+        // The ignored subfolder file must be preserved.
+        $adminSettingsFile = $this->filesystem->getRequire(
+            $this->localePath($locale) . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'settings.php'
+        );
+        $this->assertEquals(['foo' => 'Foo value', 'bar' => 'Bar value'], $adminSettingsFile);
+
+        // The non-ignored file must be updated.
+        $homeFile = $this->filesystem->getRequire(
+            $this->localePath($locale) . DIRECTORY_SEPARATOR . 'public' . DIRECTORY_SEPARATOR . 'home.php'
+        );
+        $this->assertEquals(['welcome' => 'Bienvenue'], $homeFile);
+    }
+
+    public function testItPreservesPartiallyIgnoredKeys()
+    {
+        $locale = 'fr';
+
+        // A file where only a subtree is ignored.
+        $this->addTranslationFixture($locale, [], 'validation', [
+            'required' => 'This field is required.',
+            'custom'   => [
+                'email' => 'Custom email rule.',
+            ],
+        ]);
+
+        // Only the "validation.custom" subtree is ignored.
+        app()['config']->set('translation.ignored_key_prefixes', ['validation.custom']);
+
+        // The API returns the non-ignored part of validation.php.
+        $translationsDotted = [
+            'validation.required' => 'Ce champ est obligatoire.',
+        ];
+
+        $this->saver()->call($locale, $translationsDotted);
+
+        $file = $this->filesystem->getRequire($this->localePath($locale) . DIRECTORY_SEPARATOR . 'validation.php');
+
+        // Non-ignored key comes from the API response.
+        $this->assertEquals('Ce champ est obligatoire.', $file['required']);
+
+        // Ignored subtree must survive.
+        $this->assertEquals(['email' => 'Custom email rule.'], $file['custom']);
+    }
+
     private function saver(): TranslationSaver
     {
         return app(TranslationSaver::class);


### PR DESCRIPTION
Fixes #39

## The data loss

`TranslationSaver::call()` opens with `deleteDirectory($this->localePath($locale))` — it wipes the whole locale directory, then rebuilds it from translation.io's response. The catch: keys matching `ignored_key_prefixes` are deliberately never sent to translation.io, so they never come back in the response — and since the directory was already nuked, **their files are silently gone after every `sync` / `init`.** Anything you intended to keep local-only is exactly what gets deleted.

## The fix

Snapshot the ignored keys *before* the delete, then merge them back in before writing:

- `snapshotIgnoredKeys($locale)` — walks the existing locale files (Symfony Finder), reconstructs the full dotted keys (subfolder prefix included), keeps only those matching an ignored prefix.
- `isIgnoredKey()` — reuses the exact `preg_quote` + `\b` word-boundary matching from `TranslationExtractor::ignoredKey()` so the two stay in lockstep.
- `ignoredKeyPrefixes()` — reads `translation.ignored_key_prefixes`, same as `GettextTranslationSaver` / `TranslationExtractor`.

The snapshot is merged back into `$translationsWithGroups` before writing, so it covers both fully-ignored files (`admin` → `admin.php`) and partially-ignored subtrees (`validation.custom`).

## Verified

```
PHPUnit 12.5.30
....                              4 / 4 (100%)
OK (4 tests, 8 assertions)
```

3 new tests: fully-ignored file, subfolder-ignored file, partially-ignored subtree. Full suite shows the same pre-existing failures as baseline (VCR cassette drift + a Windows path-sep case) — no regressions.

---

I matched the ignored-key regex to `TranslationExtractor` so they can't drift apart, but you've got two places now doing that prefix check — would you rather I pull it into a small shared trait/helper, or keep it duplicated-but-in-sync as it is? Happy to refactor it whichever way fits the codebase.

(I'm with Choreless — we fix and ship for small teams — but no strings, I just hit this one myself.) — Charles
